### PR TITLE
wip: this is a wip test commit

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,7 +13,7 @@ module.exports = {
       'always',
       [
         /** WIP means Working in progress，used in GitLab usually  */
-        'WIP',
+        'wip',
         /** Merge branch */
         'merge',
         'build',

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "commit-msg": "commitlint -g ./commitlint.config.js  -E HUSKY_GIT_PARAMS"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
添加 `wip` 的 commit type 

鉴于现在 commitlint 配置，只能使用小写的 commit type，所以，WIP 只能降级为 wip